### PR TITLE
Fix dataset class name mismatch

### DIFF
--- a/training/velocity_dataset.py
+++ b/training/velocity_dataset.py
@@ -3,7 +3,9 @@ import pandas as pd
 from torch.utils.data import Dataset
 from sklearn.preprocessing import MinMaxScaler
 
-class CollisionDataset(Dataset):
+class VelocityDataset(Dataset):
+    """Simple dataset for training the velocity prediction model."""
+
     def __init__(self, csv_file, x_cols=["VSV", "Headway", "VLV"], y_col="Risk", normalize=True):
         self.df = pd.read_csv(csv_file)
         self.x_cols = x_cols


### PR DESCRIPTION
## Summary
- rename `CollisionDataset` to `VelocityDataset` in the velocity dataset helper
- add a brief docstring

## Testing
- `python -m py_compile training/velocity_dataset.py`
- `python -m py_compile training/train_velocity_model.py`


------
https://chatgpt.com/codex/tasks/task_e_6844788d2bc4832a96b3f10288464350

## Summary by Sourcery

Fix the dataset helper by renaming the class to match its purpose and adding documentation.

Bug Fixes:
- Rename CollisionDataset to VelocityDataset in training/velocity_dataset.py to correct class name mismatch

Enhancements:
- Add a brief docstring to the VelocityDataset class